### PR TITLE
chore!: convert axios to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/jest": "^25.2.1",
     "@types/moxios": "^0.4.9",
     "@types/node": "^13.13.4",
+    "axios": "^0.21.0",
     "eslint": "^6.8.0",
     "jest": "^25.4.0",
     "jest-junit": "^10.0.0",
@@ -45,7 +46,9 @@
   },
   "dependencies": {
     "@types/aws4": "^1.5.1",
-    "aws4": "^1.9.1",
-    "axios": "^0.19.2"
+    "aws4": "^1.9.1"
+  },
+  "peerDependencies": {
+    "axios": ">0.19.2 < 0.22.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,12 +880,12 @@ axios@^0.19.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 babel-jest@^25.4.0:
   version "25.4.0"
@@ -1700,6 +1700,11 @@ follow-redirects@1.5.10:
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
+
+follow-redirects@^1.10.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
**Breaking change**

Axios will generally be installed as an existing dependency, so `aws4-axios` should not include it as a direct dependency.

Anyone depending on the `axios` bundled with `aws4-axios` will need to add `axios` as a direct dependency of their project:

```
npm install --save axios
```

or
```
yarn add axios
```