### PR TITLE
feat: serialize query params passed as argument

### DIFF
--- a/src/axios-custom.d.ts
+++ b/src/axios-custom.d.ts
@@ -9,3 +9,12 @@ declare module "axios/lib/helpers/isAbsoluteURL" {
 
   export default combineURLs;
 }
+
+declare module "axios/lib/helpers/buildUrl" {
+  function buildURL(
+    url: string | undefined,
+    params: any,
+    paramsSerializer: ((params: any) => string) | undefined
+  ): string;
+  export default buildURL;
+}

--- a/src/axiosInterceptor.test.ts
+++ b/src/axiosInterceptor.test.ts
@@ -2,6 +2,8 @@ import moxios from "moxios";
 import axios from "axios";
 import aws4Interceptor from ".";
 
+jest.setTimeout(1000000)
+
 describe("axios interceptor", () => {
   beforeEach(() => {
     moxios.install();
@@ -10,7 +12,30 @@ describe("axios interceptor", () => {
   afterEach(() => {
     moxios.uninstall();
   });
+  
+  it("should not mutate config object", async () => {
+    // Arrange
+    const client = axios.create();
 
+    client.interceptors.request.use(aws4Interceptor({ region: "local" }));
+
+    const url = "https://localhost/foo";
+    const config = {
+      headers: { "X-Custom-Header": "foo", "Content-Type": "application/json" },
+      params: {foo: "bar"}
+    }
+
+    moxios.stubOnce("GET", /./, {});
+
+    // Act
+    await client.get(url, config);
+
+    // Assert
+    const request = moxios.requests.first();
+    expect(request.url).toBe(`${url}?foo=bar`)
+    expect(config.params).toStrictEqual({foo: "bar"})
+  });
+  
   it("should preserve headers", async () => {
     // Arrange
     const client = axios.create();

--- a/src/axiosInterceptor.test.ts
+++ b/src/axiosInterceptor.test.ts
@@ -2,8 +2,6 @@ import moxios from "moxios";
 import axios from "axios";
 import aws4Interceptor from ".";
 
-jest.setTimeout(1000000)
-
 describe("axios interceptor", () => {
   beforeEach(() => {
     moxios.install();
@@ -13,7 +11,7 @@ describe("axios interceptor", () => {
     moxios.uninstall();
   });
   
-  it("should not mutate config object", async () => {
+  it("should not mutate request config object", async () => {
     // Arrange
     const client = axios.create();
 

--- a/src/interceptor.test.ts
+++ b/src/interceptor.test.ts
@@ -49,11 +49,40 @@ describe("interceptor", () => {
     }, undefined);
   });
 
-  it("signs query paremeters in GET requests", () => {
+  it("signs url query paremeters in GET requests", () => {
     // Arrange
     const request: AxiosRequestConfig = {
       method: "GET",
       url: "https://example.com/foobar?foo=bar",
+      headers: getDefaultHeaders(),
+      transformRequest: getDefaultTransformRequest()
+    };
+
+    const interceptor = aws4Interceptor({
+      region: "local",
+      service: "execute-api"
+    });
+
+    // Act
+    interceptor(request);
+
+    // Assert
+    expect(sign).toBeCalledWith({
+      service: "execute-api",
+      path: "/foobar?foo=bar",
+      method: "GET",
+      region: "local",
+      host: "example.com",
+      headers: {}
+    }, undefined);
+  });
+
+  it("signs query paremeters in GET requests", () => {
+    // Arrange
+    const request: AxiosRequestConfig = {
+      method: "GET",
+      url: "https://example.com/foobar",
+      params: {foo: "bar"},
       headers: getDefaultHeaders(),
       transformRequest: getDefaultTransformRequest()
     };

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -1,5 +1,6 @@
-import { sign } from "aws4";
 import { AxiosRequestConfig } from "axios";
+import { sign } from "aws4";
+import buildUrl from "axios/lib/helpers/buildUrl";
 import combineURLs from "axios/lib/helpers/combineURLs";
 import isAbsoluteURL from "axios/lib/helpers/isAbsoluteURL";
 
@@ -44,6 +45,11 @@ export const aws4Interceptor = (options?: InterceptorOptions, credentials?: Cred
     throw new Error("No URL present in request config, unable to sign request");
   }
 
+  if(config.params) {
+    config.url = buildUrl(config.url, config.params, config.paramsSerializer);
+    delete config.params;
+  }
+  
   let url = config.url;
 
   if (config.baseURL && !isAbsoluteURL(config.url)) {


### PR DESCRIPTION
Axios allows for query params to be passed as part of the config argument (instead of the url). This commit serializes the query params before signing. Before the query params were discarded and the signature did not match.

I added a separate test for this. Typing is rather loose but aligns with the @types/axios package.

Parameter serialization should be independent of whether a relative or absolute url was passed in the req config, therefore I added it as a first step.