### PR TITLE
feat: export Credentials and InterceptorOptions types from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-import { aws4Interceptor } from "./interceptor";
+import {
+  aws4Interceptor,
+  Credentials,
+  InterceptorOptions,
+} from "./interceptor";
 import { getAuthErrorMessage } from "./getAuthErrorMessage";
 
 /**
@@ -8,4 +12,9 @@ export const interceptor = aws4Interceptor;
 
 export default aws4Interceptor;
 
-export { getAuthErrorMessage, aws4Interceptor };
+export {
+  getAuthErrorMessage,
+  aws4Interceptor,
+  Credentials,
+  InterceptorOptions,
+};


### PR DESCRIPTION
this will allow the types to be imported from `"aws4-axios"` rather than `"aws4-axios/dist/interceptor"`