### PR TITLE
feat: custom CredentialsProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ const interceptor = aws4Interceptor(
 );
 ```
 
+You can also pass a custom `CredentialsProvider` factory instead
+
+```typescript
+const customCredentialsProvider = {
+  getCredentials: async () => {
+    return Promise.resolve({
+      accessKeyId: "custom-provider-access-key-id",
+      secretAccessKey: "custom-provider-secret-access-key"
+    })
+  }
+}
+
+const interceptor = aws4Interceptor(
+  {
+    region: "eu-west-2",
+    service: "execute-api",
+  },
+  customCredentialsProvider
+);
+```
+
 ## Assuming the IAM Role
 
 You can pass a parameter to assume the IAM Role with AWS STS

--- a/src/credentials/isCredentialsProvider.ts
+++ b/src/credentials/isCredentialsProvider.ts
@@ -1,0 +1,7 @@
+import { CredentialsProvider } from "./credentialsProvider";
+
+// type guard
+export const isCredentialsProvider = (
+  variableToCheck: unknown
+): variableToCheck is CredentialsProvider =>
+  (variableToCheck as CredentialsProvider)?.getCredentials !== undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   Credentials,
   InterceptorOptions,
 } from "./interceptor";
+import { CredentialsProvider } from "./credentials/credentialsProvider";
 import { getAuthErrorMessage } from "./getAuthErrorMessage";
 
 /**
@@ -16,5 +17,6 @@ export {
   getAuthErrorMessage,
   aws4Interceptor,
   Credentials,
+  CredentialsProvider,
   InterceptorOptions,
 };


### PR DESCRIPTION
Closes #271. Includes test and revised documentation.

It is backwards compatible, so no breaking change.