### PR TITLE
fix dependabot axios bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "4.17.15",
     "mixin-deep": "2.0.1",
     "set-value": "3.0.1",
-    "axios": "0.21.1"
+    "axios": "0.21.2"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/axiosInterceptor.test.ts
+++ b/src/axiosInterceptor.test.ts
@@ -74,7 +74,7 @@ describe("axios interceptor", () => {
     // Assert
     const request = moxios.requests.first();
     expect(request.headers["Content-Type"]).toEqual(
-      "application/json;charset=utf-8"
+      "application/json"
     );
   });
 
@@ -96,7 +96,7 @@ describe("axios interceptor", () => {
     // Assert
     const request = moxios.requests.first();
     expect(request.headers["Content-Type"]).toEqual(
-      "application/json;charset=utf-8"
+      "application/json"
     );
   });
 });

--- a/src/interceptor.test.ts
+++ b/src/interceptor.test.ts
@@ -165,7 +165,7 @@ describe("interceptor", () => {
         region: "local",
         host: "example.com",
         body: '{"foo":"bar"}',
-        headers: { "Content-Type": "application/json;charset=utf-8" },
+        headers: { "Content-Type": "application/json" },
       },
       undefined
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,12 +2755,12 @@ aws4@^1.8.0, aws4@^1.9.1:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@0.21.1, axios@^0.21.0, axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+axios@0.21.2, axios@^0.21.0, axios@^0.21.1:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
+  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.0"
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -5084,10 +5084,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.10.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
-  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
+follow-redirects@^1.14.0:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
axios v0.21.2 removes the charset from JSON Content-Type headers (see [PR](https://github.com/axios/axios/issues/2154)). This adjusts the tests to compensate for that change.
