### PR TITLE
chore: upgrade to Axios 0.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,7 @@
   "bugs": {
     "url": "https://github.com/jamesmbourne/aws4-axios/issues"
   },
-  "keywords": [
-    "aws4",
-    "awsv4",
-    "signature",
-    "axios",
-    "interceptor"
-  ],
+  "keywords": ["aws4", "awsv4", "signature", "axios", "interceptor"],
   "resolutions": {
     "lodash": "4.17.15",
     "mixin-deep": "2.0.1",
@@ -42,22 +36,21 @@
     "@aws-sdk/client-cloudformation": "^3.4.1",
     "@aws-sdk/client-sts": "^3.4.1",
     "@types/jest": "^27.0.1",
-    "@types/moxios": "^0.4.9",
     "@types/node": "^14.14.21",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
     "axios": "^0.21.0",
+    "axios-mock-adapter": "^1.20.0",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^8.3.0",
     "husky": "^7.0.1",
     "jest": "^26.6.3",
     "lint-staged": "^11.1.2",
-    "moxios": "^0.4.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
     "semantic-release": "^17.3.3",
-    "ts-jest": "^26.5.0",
     "serverless": "^2.22.0",
+    "ts-jest": "^26.5.0",
     "typescript": "^4.1.3"
   },
   "dependencies": {
@@ -74,10 +67,7 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
-      "eslint --cache --fix",
-      "prettier --write"
-    ]
+    "*.{ts,tsx}": ["eslint --cache --fix", "prettier --write"]
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "4.17.15",
     "mixin-deep": "2.0.1",
     "set-value": "3.0.1",
-    "axios": "0.21.1"
+    "axios": "0.21.2"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,13 @@
   "bugs": {
     "url": "https://github.com/jamesmbourne/aws4-axios/issues"
   },
-  "keywords": ["aws4", "awsv4", "signature", "axios", "interceptor"],
+  "keywords": [
+    "aws4",
+    "awsv4",
+    "signature",
+    "axios",
+    "interceptor"
+  ],
   "resolutions": {
     "lodash": "4.17.15",
     "mixin-deep": "2.0.1",
@@ -39,7 +45,7 @@
     "@types/node": "^14.14.21",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
-    "axios": "^0.21.0",
+    "axios": "^0.24.0",
     "axios-mock-adapter": "^1.20.0",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^8.3.0",
@@ -67,7 +73,10 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx}": ["eslint --cache --fix", "prettier --write"]
+    "*.{ts,tsx}": [
+      "eslint --cache --fix",
+      "prettier --write"
+    ]
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "4.17.15",
     "mixin-deep": "2.0.1",
     "set-value": "3.0.1",
-    "axios": "0.21.2"
+    "axios": "0.25.0"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -45,7 +45,7 @@
     "@types/node": "^14.14.21",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
-    "axios": "^0.24.0",
+    "axios": "^0.25.0",
     "axios-mock-adapter": "^1.20.0",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^8.3.0",
@@ -65,7 +65,7 @@
     "aws4": "^1.9.1"
   },
   "peerDependencies": {
-    "axios": ">0.19.2 < 0.22.0"
+    "axios": ">0.25.0"
   },
   "husky": {
     "hooks": {

--- a/src/__tests__/apiGateway.it.ts
+++ b/src/__tests__/apiGateway.it.ts
@@ -199,9 +199,7 @@ describe("with credentials from environment variables", () => {
 
     expect(error).toBe(undefined);
     expect(result?.status).toEqual(200);
-    expect(result?.data.headers["content-type"]).toBe(
-      "application/json;charset=utf-8"
-    );
+    expect(result?.data.headers["content-type"]).toBe("application/json");
   });
 });
 

--- a/src/axiosInterceptor.test.ts
+++ b/src/axiosInterceptor.test.ts
@@ -74,7 +74,7 @@ describe("axios interceptor", () => {
     // Assert
     const request = moxios.requests.first();
     expect(request.headers["Content-Type"]).toEqual(
-      "application/json;charset=utf-8"
+      "application/json"
     );
   });
 
@@ -96,7 +96,7 @@ describe("axios interceptor", () => {
     // Assert
     const request = moxios.requests.first();
     expect(request.headers["Content-Type"]).toEqual(
-      "application/json;charset=utf-8"
+      "application/json"
     );
   });
 });

--- a/src/axiosInterceptor.test.ts
+++ b/src/axiosInterceptor.test.ts
@@ -1,14 +1,15 @@
-import moxios from "moxios";
 import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import aws4Interceptor from ".";
 
 describe("axios interceptor", () => {
-  beforeEach(() => {
-    moxios.install();
+  let mock: MockAdapter;
+  beforeAll(() => {
+    mock = new MockAdapter(axios);
   });
 
   afterEach(() => {
-    moxios.uninstall();
+    mock.reset();
   });
 
   it("should not mutate request config object", async () => {
@@ -23,13 +24,14 @@ describe("axios interceptor", () => {
       params: { foo: "bar" },
     };
 
-    moxios.stubOnce("GET", /./, {});
+    mock.onGet().replyOnce(200, {});
 
     // Act
     await client.get(url, config);
 
     // Assert
-    const request = moxios.requests.first();
+    const request = mock.history.get[0];
+    // const request = moxios.requests.first();
     expect(request.url).toBe(`${url}?foo=bar`);
     expect(config.params).toStrictEqual({ foo: "bar" });
   });
@@ -44,7 +46,7 @@ describe("axios interceptor", () => {
 
     const url = "https://localhost/foo";
 
-    moxios.stubOnce("POST", url, {});
+    mock.onPost(url).replyOnce(200, {});
 
     // Act
     await client.post(url, data, {
@@ -52,10 +54,10 @@ describe("axios interceptor", () => {
     });
 
     // Assert
-    const request = moxios.requests.first();
-    expect(request.headers["Content-Type"]).toEqual("application/json");
-    expect(request.headers["X-Custom-Header"]).toEqual("foo");
-    expect(request.headers["Authorization"]).toContain("AWS");
+    const request = mock.history.post[0];
+    expect(request.headers?.["Content-Type"]).toEqual("application/json");
+    expect(request.headers?.["X-Custom-Header"]).toEqual("foo");
+    expect(request.headers?.["Authorization"]).toContain("AWS");
   });
 
   it("should preserve default headers - without interceptor", async () => {
@@ -66,16 +68,14 @@ describe("axios interceptor", () => {
 
     const url = "https://localhost/foo";
 
-    moxios.stubOnce("POST", url, {});
+    mock.onPost(url).replyOnce(200, {});
 
     // Act
     await client.post(url, data, {});
 
     // Assert
-    const request = moxios.requests.first();
-    expect(request.headers["Content-Type"]).toEqual(
-      "application/json"
-    );
+    const request = mock.history.post[0];
+    expect(request.headers?.["Content-Type"]).toEqual("application/json");
   });
 
   it("should preserve default headers - with interceptor", async () => {
@@ -88,15 +88,13 @@ describe("axios interceptor", () => {
 
     const url = "https://localhost/foo";
 
-    moxios.stubOnce("POST", url, {});
+    mock.onPost(url).replyOnce(200, {});
 
     // Act
     await client.post(url, data, {});
 
     // Assert
-    const request = moxios.requests.first();
-    expect(request.headers["Content-Type"]).toEqual(
-      "application/json"
-    );
+    const request = mock.history.post[0];
+    expect(request.headers?.["Content-Type"]).toEqual("application/json");
   });
 });

--- a/src/interceptor.test.ts
+++ b/src/interceptor.test.ts
@@ -1,5 +1,5 @@
 import { sign } from "aws4";
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { AxiosRequestConfig, AxiosRequestHeaders } from "axios";
 import { aws4Interceptor } from ".";
 import { CredentialsProvider } from "./credentials/credentialsProvider";
 
@@ -25,14 +25,14 @@ const mockCustomProvider: CredentialsProvider = {
   },
 };
 
-const getDefaultHeaders = () => ({
-  common: { Accept: "application/json, text/plain, */*" },
-  delete: {},
-  get: {},
-  head: {},
-  post: { "Content-Type": "application/x-www-form-urlencoded" },
-  put: { "Content-Type": "application/x-www-form-urlencoded" },
-  patch: { "Content-Type": "application/x-www-form-urlencoded" },
+const getDefaultHeaders = (): AxiosRequestHeaders => ({
+  // common: { Accept: "application/json, text/plain, */*" },
+  // delete: {},
+  // get: {},
+  // head: {},
+  // post: { "Content-Type": "application/x-www-form-urlencoded" },
+  // put: { "Content-Type": "application/x-www-form-urlencoded" },
+  // patch: { "Content-Type": "application/x-www-form-urlencoded" },
 });
 
 const getDefaultTransformRequest = () => axios.defaults.transformRequest;

--- a/src/interceptor.test.ts
+++ b/src/interceptor.test.ts
@@ -165,7 +165,7 @@ describe("interceptor", () => {
         region: "local",
         host: "example.com",
         body: '{"foo":"bar"}',
-        headers: { "Content-Type": "application/json;charset=utf-8" },
+        headers: { "Content-Type": "application/json" },
       },
       undefined
     );

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig } from "axios";
+import { AxiosRequestConfig, AxiosRequestHeaders, Method } from "axios";
 import { sign } from "aws4";
 import buildUrl from "axios/lib/helpers/buildURL";
 import combineURLs from "axios/lib/helpers/combineURLs";
@@ -37,7 +37,7 @@ export interface InterceptorOptions {
 
 export interface SigningOptions {
   host?: string;
-  headers?: unknown;
+  headers?: AxiosRequestHeaders;
   path?: string;
   body?: unknown;
   region?: string;
@@ -51,6 +51,11 @@ export interface Credentials {
   secretAccessKey: string;
   sessionToken?: string;
 }
+
+export type InternalAxiosHeaders = Record<
+  Method | "common",
+  Record<string, string>
+>;
 
 /**
  * Create an interceptor to add to the Axios request chain. This interceptor
@@ -117,7 +122,8 @@ export const aws4Interceptor = (
       put,
       patch,
       ...headersToSign
-    } = headers;
+    } = headers as any as InternalAxiosHeaders;
+    // Axios type definitions do not match the real shape of this object
 
     const signingOptions: SigningOptions = {
       method: method && method.toUpperCase(),
@@ -127,7 +133,7 @@ export const aws4Interceptor = (
       service: options?.service,
       signQuery: options?.signQuery,
       body: transformedData,
-      headers: headersToSign,
+      headers: headersToSign as any,
     };
 
     const resolvedCredentials = await credentialsProvider.getCredentials();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,12 +2755,12 @@ aws4@^1.8.0, aws4@^1.9.1:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@0.21.1, axios@^0.21.0, axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+axios@0.21.2, axios@^0.21.0, axios@^0.21.1:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
+  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.0"
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -5084,10 +5084,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.10.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
-  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
+follow-redirects@^1.14.0:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
 
 forever-agent@~0.6.1:
   version "0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,19 +2757,12 @@ axios-mock-adapter@^1.20.0:
     is-blob "^2.1.0"
     is-buffer "^2.0.5"
 
-axios@0.21.2, axios@^0.21.1:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+axios@0.25.0, axios@^0.21.1, axios@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
+  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
   dependencies:
-    follow-redirects "^1.14.0"
-
-axios@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
-  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
-  dependencies:
-    follow-redirects "^1.14.4"
+    follow-redirects "^1.14.7"
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -5093,10 +5086,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4:
-  version "1.14.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
-  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
+follow-redirects@^1.14.7:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 forever-agent@~0.6.1:
   version "0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2764,12 +2764,12 @@ axios@0.21.2, axios@^0.21.1:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.21.0:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.4"
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -5093,7 +5093,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.14.0:
+follow-redirects@^1.14.0, follow-redirects@^1.14.4:
   version "1.14.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
   integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,13 +2140,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/moxios@^0.4.9":
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/@types/moxios/-/moxios-0.4.10.tgz#0762de3157714f8078a3c79ba65dcec4da701bfe"
-  integrity sha512-OGXB0kvKJT4KAdy4OzdGkBhNJ3f1x3FsqUq6elUBLcaBsVMy09hErlyhq2+zwEwcNbv1DGmksASW06XRISnxUQ==
-  dependencies:
-    axios "^0.21.1"
-
 "@types/node@*", "@types/node@>= 8", "@types/node@^14.14.21":
   version "14.14.25"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.25.tgz#15967a7b577ff81383f9b888aa6705d43fbbae93"
@@ -2755,10 +2748,26 @@ aws4@^1.8.0, aws4@^1.9.1:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@0.21.2, axios@^0.21.0, axios@^0.21.1:
+axios-mock-adapter@^1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz#21f5b4b625306f43e8c05673616719da86e20dcb"
+  integrity sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-blob "^2.1.0"
+    is-buffer "^2.0.5"
+
+axios@0.21.2, axios@^0.21.1:
   version "0.21.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
   integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
+axios@^0.21.0:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
 
@@ -4846,7 +4855,7 @@ fast-base64-decode@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
   integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -5085,9 +5094,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.14.0:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
+  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -5946,10 +5955,20 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-blob@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-blob/-/is-blob-2.1.0.tgz#e36cd82c90653f1e1b930f11baf9c64216a05385"
+  integrity sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.4, is-callable@^1.2.2:
   version "1.2.2"
@@ -7790,11 +7809,6 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
-
-moxios@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/moxios/-/moxios-0.4.0.tgz#fc0da2c65477d725ca6b9679d58370ed0c52f53b"
-  integrity sha1-/A2ixlR31yXKa5Z51YNw7QxS9Ts=
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
~~Builds off of https://github.com/jamesmbourne/aws4-axios/pull/436; leaving as draft until that's applied.~~

Changes the mocking library for axios from moxios to axios-mock-adapter, as moxios doesn't seem to behave with newer versions of axios. With that change applied, we can then update axios itself to 0.24.

