### PR TITLE
feat: add DevContainer to repository to help new contributors

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.231.2/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="18-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# Ensure the latest NPM version is installed regardless to which Node version we are running.
+RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install-latest-npm"
+
+RUN npm install -g aws-cdk

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.231.2/containers/typescript-node
+{
+    "name": "Node.js & TypeScript",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "EditorConfig.EditorConfig",
+                "amazonwebservices.aws-toolkit-vscode" // AWS Toolkit Support
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "npm ci",
+    // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "node",
+    "features": {
+        "git": "latest",
+        "github-cli": "latest",
+        "aws-cli": "latest"
+    },
+    "mounts": [
+        "source=${env:HOME}${env:USERPROFILE}/.aws,target=/home/node/.aws,type=bind"
+    ]
+}


### PR DESCRIPTION
Personally I always like to develop in a [DevContainer](https://code.visualstudio.com/docs/devcontainers/containers) and really appreciate it when it's already available in a Github project, to build my previous pr #889 I've added these DevContainer configuration files.

- Based on Node 18 (necessary for semantic-release)
- Default vscode extensions for eslint/editorconfig/aws toolkit

Very minimal but enough to contribute to the project without needing local dependencies.