### PR TITLE
feat (#1127): add assumeRoleSessionName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ const interceptor = aws4Interceptor({
     region: "eu-west-2",
     service: "execute-api",
     assumeRoleArn: "arn:aws:iam::111111111111:role/MyRole",
+    assumeRoleSessionName: "MyApiClient", // optional, default value is "axios"
   },
 });
 ```

--- a/src/credentials/assumeRoleCredentialsProvider.ts
+++ b/src/credentials/assumeRoleCredentialsProvider.ts
@@ -17,6 +17,7 @@ export class AssumeRoleCredentialsProvider implements CredentialsProvider {
       ...options,
       region: options.region || process.env.AWS_REGION,
       expirationMarginSec: options.expirationMarginSec || 5,
+      roleSessionName: options.roleSessionName || "axios",
     };
 
     this.sts = new STSClient({ region: this.options.region });
@@ -48,7 +49,7 @@ export class AssumeRoleCredentialsProvider implements CredentialsProvider {
     const res = await this.sts.send(
       new AssumeRoleCommand({
         RoleArn: this.options.roleArn,
-        RoleSessionName: "axios",
+        RoleSessionName: this.options.roleSessionName,
       })
     );
 
@@ -64,10 +65,12 @@ export interface AssumeRoleCredentialsProviderOptions {
   roleArn: string;
   region?: string;
   expirationMarginSec?: number;
+  roleSessionName?: string;
 }
 
 export interface ResolvedAssumeRoleCredentialsProviderOptions {
   roleArn: string;
   region?: string;
   expirationMarginSec: number;
+  roleSessionName: string;
 }

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -38,6 +38,14 @@ export interface InterceptorOptions {
    * Used only if assumeRoleArn is provided.
    */
   assumedRoleExpirationMarginSec?: number;
+  /**
+   * An identifier for the assumed role session.
+   * Use the role session name to uniquely identify a session when the same role is
+   * assumed by different principals or for different reasons.
+   * In cross-account scenarios, the role session name is visible to,
+   * and can be logged by the account that owns the role. 
+   */
+  assumeRoleSessionName?: string;
 }
 
 export interface SigningOptions {
@@ -106,6 +114,7 @@ export const aws4Interceptor = <D = any>({
       roleArn: options.assumeRoleArn,
       region: options.region,
       expirationMarginSec: options.assumedRoleExpirationMarginSec,
+      roleSessionName: options.assumeRoleSessionName,
     });
   } else {
     credentialsProvider = new SimpleCredentialsProvider(credentials);


### PR DESCRIPTION
Here's a quick implementation for adding the assumeRoleSessionName option (#1127).
There's no test case added. I am happy to try but this is why I hesitated:

- It seems interceptor.test.ts does not have knowledge of AssumeRoleCredentialsProvider logic
- It seems assumeRoleCredentialsProvider.test does not have knowledge of the interceptor logic
- So that they are currently partitioned. This probably is a design decision.
- The change in this PR has two parts:
  - Passing the configuration from the interceptor to the AssumeRoleCredentialsProvider
  - Passing the configuration from AssumeRoleCredentialsProvider to AWS STS
- So that I am not sure what the best way is to test newly added logic.