### PR TITLE
feat: add support for X-Amz-Content-Sha256.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ const interceptor = aws4Interceptor({
 });
 ```
 
+Newer services, such as [Amazon OpenSearch Serverless](https://aws.amazon.com/opensearch-service/features/serverless/), require a content SHA. Pass `addContentSha` to `options` to enable adding an `X-Amz-Content-Sha256` header to the request.
+
+```typescript
+const interceptor = aws4Interceptor({
+  options: {
+    region: "eu-west-2",
+    service: "aoss",
+    addContentSha: true,
+  },
+  credentials: {
+    accessKeyId: "",
+    secretAccessKey: "",
+  },
+});
+```
+
 # Migration to v3
 
 The interface for options changed in v3. You should now pass a single object with configuration.

--- a/src/interceptor.test.ts
+++ b/src/interceptor.test.ts
@@ -1,4 +1,5 @@
 import { sign } from "aws4";
+
 import axios, {
   AxiosHeaders,
   AxiosRequestHeaders,
@@ -37,6 +38,7 @@ const getDefaultTransformRequest = () => axios.defaults.transformRequest;
 beforeEach(() => {
   (sign as jest.Mock).mockReset();
 });
+
 
 describe("interceptor", () => {
   it("signs GET requests", async () => {
@@ -215,6 +217,35 @@ describe("interceptor", () => {
       },
       undefined,
     );
+
+    expect(request.headers['X-Amz-Content-Sha256']).toBeUndefined()
+  });
+
+  it("adds X-Amz-Content-Sha256 for a string payload", async () => {
+    // Arrange
+    const data = "foobar";
+    const request: InternalAxiosRequestConfig = {
+      method: "POST",
+      url: "https://example.com/foobar",
+      data,
+      headers: getDefaultHeaders(),
+      transformRequest: getDefaultTransformRequest(),
+    };
+
+    const interceptor = aws4Interceptor({
+      options: {
+        region: "local",
+        service: "execute-api",
+        addContentSha: true
+      },
+      instance: axios,
+    });
+
+    // Act
+    await interceptor(request);
+
+    // Assert
+    expect(request.headers['X-Amz-Content-Sha256']).toEqual('c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
   });
 
   it("passes Content-Type header to be signed", async () => {
@@ -332,6 +363,31 @@ describe("interceptor", () => {
       },
       undefined,
     );
+  });
+
+  it("passes option to add a content SHA", async () => {
+    // Arrange
+    const request: InternalAxiosRequestConfig = {
+      method: "GET",
+      url: "https://example.com/foobar",
+      headers: getDefaultHeaders(),
+      transformRequest: getDefaultTransformRequest(),
+    };
+
+    const interceptor = aws4Interceptor({
+      instance: axios,
+      options: {
+        region: "local",
+        service: "execute-api",
+        addContentSha: true,
+      },
+    });
+
+    // Act
+    await interceptor(request);
+
+    // Assert
+    expect(request.headers['X-Amz-Content-Sha256']).toEqual('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
   });
 });
 

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -13,6 +13,7 @@ import { CredentialsProvider } from ".";
 import { AssumeRoleCredentialsProvider } from "./credentials/assumeRoleCredentialsProvider";
 import { isCredentialsProvider } from "./credentials/isCredentialsProvider";
 import { SimpleCredentialsProvider } from "./credentials/simpleCredentialsProvider";
+import { createHash } from "crypto";
 
 export interface InterceptorOptions {
   /**
@@ -27,6 +28,10 @@ export interface InterceptorOptions {
    * Whether to sign query instead of adding Authorization header. Default to false.
    */
   signQuery?: boolean;
+  /**
+   * Whether to add a X-Amz-Content-Sha256 header.
+   */
+  addContentSha?: boolean;
   /**
    * ARN of the IAM Role to be assumed to get the credentials from.
    * The credentials will be cached and automatically refreshed as needed.
@@ -196,6 +201,10 @@ export const aws4Interceptor = <D = any>({
         ...config.params,
         ...Object.fromEntries(signedUrl.searchParams.entries())
       }
+    }
+
+    if (options?.addContentSha) {
+      config.headers.set('X-Amz-Content-Sha256', createHash('sha256').update(transformedData ?? '', 'utf8').digest('hex'))
     }
 
     return config;


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/opensearch-api-specification/pull/483 where I was trying to add support for Amazon OpenSearch Serverless to already working support for Amazon Managed OpenSearch. The serverless implementation requires an `X-Amz-Content-Sha256` for all requests, including `GET` with or without a body. Adds an option to add the header.

Before:

```
[INFO] Authenticating using SigV4 with ... (us-west-2) ...
OpenSearch 2.1

[INFO] => POST /_bulk ({}) [application/x-ndjson] "{\"create\":{\"_index\":\"movies\"}}\n{\"director\":\"Bennett Miller\",\"title\":\"Moneyball\",\"year\":2011}\n"
[INFO] <= 403 (application/json) | {
  "reason": "403 Forbidden",
  "type": "Forbidden"
}
[INFO] => DELETE /books,movies ({}) [application/json] 
[INFO] <= 403 (application/json) | {
  "reason": "403 Forbidden",
  "type": "Forbidden"
}
```

After:

```
[INFO] Authenticating using SigV4 with ... (us-west-2) ...
OpenSearch 2.1

[INFO] => POST /movies/_doc ({
  "refresh": true
}) [application/json] {
  "director": "Bennett Miller",
  "title": "Moneyball",
  "year": 2011
}
[INFO] <= 400 (application/json) | {
  "root_cause": [
    {
      "type": "status_exception",
      "reason": "true refresh policy is not supported."
    }
  ],
  "type": "status_exception",
  "reason": "true refresh policy is not supported."
}
[INFO] => DELETE /movies ({}) [application/json] 
[INFO] <= 200 (application/json; charset=UTF-8) | {
  "acknowledged": true
}
```

Open to renaming the option to something else, adding more tests as needed, etc.